### PR TITLE
Update ccsf.txt

### DIFF
--- a/lib/domains/edu/ccsf.txt
+++ b/lib/domains/edu/ccsf.txt
@@ -1,1 +1,12 @@
 City College of San Francisco
+
+# Student Email Domain
+mail.ccsf.edu
+
+https://www.ccsf.edu
+
+https://www.ccsf.edu/en/educational-programs/cte/exploring/itcs.html
+
+https://www.ccsf.edu/en/educational-programs/school-and-departments/school-of-science-and-mathematics/computer-science.html
+
+https://www.ccsf.edu/dam/ccsf/documents/OfficeOfInstruction/Catalog/Programs/ComputerScience/ComputerScienceMajor.pdf


### PR DESCRIPTION
Student email addresses are given the subdomain of @mail.ccsf.edu and a part of their first and last names.

Staff and Faculty just have @ccsf.edu.

Cheers!
-Geoff Norman